### PR TITLE
Fix bug made apparent by recent refactor

### DIFF
--- a/changelog/73.bugfix.rst
+++ b/changelog/73.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug introduced in recent refactor where images were transposed due to array vs cartesian array indexing.

--- a/xrayvision/tests/test_imaging.py
+++ b/xrayvision/tests/test_imaging.py
@@ -2,7 +2,7 @@ import astropy.units as apu
 import numpy as np
 import pytest
 from astropy.convolution.kernels import Gaussian2DKernel
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 from sunpy.map import Map
 
 from xrayvision.imaging import image_to_vis, map_to_vis, vis_psf_image, vis_to_image, vis_to_map
@@ -161,8 +161,8 @@ def test_map_to_vis(pos, pixel):
     pixel = pixel * apu.arcsec / apu.pix
 
     # Calculate full u, v coverage so will be equivalent to a discrete Fourier transform (DFT)
-    u = generate_uv(m * apu.pix, phase_center=pos[0], pixel_size=pixel[0])
-    v = generate_uv(n * apu.pix, phase_center=pos[1], pixel_size=pixel[1])
+    v = generate_uv(m * apu.pix, phase_center=pos[0], pixel_size=pixel[0])
+    u = generate_uv(n * apu.pix, phase_center=pos[1], pixel_size=pixel[1])
     u, v = np.meshgrid(u, v, indexing="ij")
     u, v = np.array([u, v]).reshape(2, size) / apu.arcsec
 
@@ -181,10 +181,10 @@ def test_map_to_vis(pos, pixel):
     mp = Map((data, header))
     vis = map_to_vis(mp, u=u, v=v)
 
-    assert np.array_equal(vis.phase_center, pos)
+    assert_array_equal(vis.phase_center, pos)
 
     res = vis_to_image(vis, shape=(m, n) * apu.pixel, pixel_size=pixel)
-    assert np.allclose(res, data)
+    assert_allclose(res, data)
 
 
 def test_vis_to_image():
@@ -255,8 +255,8 @@ def test_vis_to_image_invalid_pixel_size():
 def test_vis_to_map(m, n, pos, pixel):
     pos = pos * apu.arcsec
     pixel = pixel * apu.arcsec / apu.pix
-    u = generate_uv(m * apu.pix, phase_center=pos[0], pixel_size=pixel[0])
-    v = generate_uv(n * apu.pix, phase_center=pos[1], pixel_size=pixel[1])
+    v = generate_uv(m * apu.pix, phase_center=pos[0], pixel_size=pixel[0])
+    u = generate_uv(n * apu.pix, phase_center=pos[1], pixel_size=pixel[1])
     u, v = np.meshgrid(u, v, indexing="ij")
     uv = np.array([u, v]).reshape(2, m * n) / apu.arcsec
     u, v = uv

--- a/xrayvision/tests/test_transform.py
+++ b/xrayvision/tests/test_transform.py
@@ -113,10 +113,10 @@ def test_generate_uv_offset_size(phase_center, pixel_size):
 @pytest.mark.parametrize("center", [(0, 0), (-1, 1), (1, -1), (1, 1)])
 def test_dft_idft(shape, pixel_size, center):
     data = np.arange(np.prod(shape)).reshape(shape)
-    uu = generate_uv(
+    vv = generate_uv(
         shape[0] * apu.pix, phase_center=center[0] * apu.arcsec, pixel_size=pixel_size[0] * apu.arcsec / apu.pix
     )
-    vv = generate_uv(
+    uu = generate_uv(
         shape[1] * apu.pix, phase_center=center[1] * apu.arcsec, pixel_size=pixel_size[1] * apu.arcsec / apu.pix
     )
     u, v = np.meshgrid(uu, vv, indexing="ij")
@@ -386,13 +386,13 @@ def test_fft_equivalence():
     center = (1, 1)
 
     data = np.arange(np.prod(shape)).reshape(shape)
-    uu = generate_uv(
+    vv = generate_uv(
         shape[0] * apu.pix, phase_center=center[0] * apu.arcsec, pixel_size=pixel[0] * apu.arcsec / apu.pix
     )
-    vv = generate_uv(
+    uu = generate_uv(
         shape[1] * apu.pix, phase_center=center[1] * apu.arcsec, pixel_size=pixel[1] * apu.arcsec / apu.pix
     )
-    u, v = np.meshgrid(uu, vv, indexing="ij")
+    u, v = np.meshgrid(uu, vv)
     u = u.flatten()
     v = v.flatten()
 

--- a/xrayvision/transform.py
+++ b/xrayvision/transform.py
@@ -154,10 +154,11 @@ def dft_map(
 
     """
     m, n = input_array.shape * apu.pix
-    x = generate_xy(m, phase_center=phase_center[0], pixel_size=pixel_size[0])  # type: ignore
-    y = generate_xy(n, phase_center=phase_center[1], pixel_size=pixel_size[1])  # type: ignore
+    # python array index in row, column hence y, x
+    y = generate_xy(m, phase_center=phase_center[0], pixel_size=pixel_size[0])  # type: ignore
+    x = generate_xy(n, phase_center=phase_center[1], pixel_size=pixel_size[1])  # type: ignore
 
-    x, y = np.meshgrid(x, y, indexing="ij")
+    x, y = np.meshgrid(x, y)
     uv = np.vstack([u, v])
     # Check units are correct for exp need to be dimensionless and then remove units for speed
     if (uv[0, :] * x[0, 0]).unit == apu.dimensionless_unscaled and (
@@ -220,10 +221,11 @@ def idft_map(
 
     """
     m, n = shape
-    x = generate_xy(m, phase_center=phase_center[0], pixel_size=pixel_size[0])  # type: ignore
-    y = generate_xy(n, phase_center=phase_center[1], pixel_size=pixel_size[1])  # type: ignore
+    # python array index in row, column hence y, x
+    y = generate_xy(m, phase_center=phase_center[0], pixel_size=pixel_size[0])  # type: ignore
+    x = generate_xy(n, phase_center=phase_center[1], pixel_size=pixel_size[1])  # type: ignore
 
-    x, y = np.meshgrid(x, y, indexing="ij")
+    x, y = np.meshgrid(x, y)
 
     if weights is None:
         weights = np.ones(input_vis.shape)


### PR DESCRIPTION
Was always a little unclear to me but now I think it makes sense. In the transform code we use/ generate `x`, `y` and `u`, `v`. By convention `x`, `u` are expected to move left/right across or in the column direction while `y`, `v` move down/up vertically or in the row direction. Numpy arrays are row major, the 1st index is row 2nd is column but there was some inconsistency with applying this in the code.

* `x`, `u` are in the col direction, `y`, `v` in the row direction python is row, col order